### PR TITLE
automatically add -latomic/-lpthread if necessary

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -66,4 +66,4 @@ Collate:
     'samc.R'
     'survival.R'
     'zzz.R'
-LinkingTo: Rcpp (>= 1.0.5), RcppEigen (>= 0.3.3.9.1), RcppThread (>= 1.0.0)
+LinkingTo: Rcpp (>= 1.0.5), RcppEigen (>= 0.3.3.9.1), RcppThread (>= 2.1.3)

--- a/src/Makevars
+++ b/src/Makevars
@@ -1,6 +1,5 @@
-## With Rcpp 0.11.0 and later, we no longer need to set PKG_LIBS as there is
-## no user-facing library. The include path to headers is already set by R.
-#PKG_LIBS =
+## Sets -latomic/-lpthread if required by the system.
+PKG_LIBS = `"$(R_HOME)/bin/Rscript" -e "RcppThread::LdFlags()"`
 
 ## With R 3.1.0 or later, you can uncomment the following line to tell R to
 ## enable compilation with C++11 (or even C++14) where available


### PR DESCRIPTION
This fixes the ERROR on CRAN's [r-devel-linux-x86_64-debian-clang](https://cran.rstudio.com/web/checks/check_results_samc.html). See also https://github.com/tnagler/RcppThread#in-another-r-package.